### PR TITLE
Pull request for issue 95

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -7,7 +7,7 @@
     __kernel_settings_required_facts
 
 - name: Set platform/version specific variables
-  include_vars: "{{ lookup('first_found', ffparams) }}"
+  include_vars: "{{ lookup('ansible.builtin.first_found', ffparams) }}"
   vars:
     ffparams:
       files:


### PR DESCRIPTION
In Ansible 2.9.13 there are already namespaces so suggestion for the refactoring of this system role to it to use already anisble.builtin.first_found. 
Tested it an worked